### PR TITLE
Fix league season retrieval bug

### DIFF
--- a/api/ForgetTheBookie.Api/Controllers/AuthController.cs
+++ b/api/ForgetTheBookie.Api/Controllers/AuthController.cs
@@ -107,12 +107,12 @@ namespace ForgetTheBookie.Api.Controllers
         {
             _logger.LogInformation("Refresh called");
 
-            var prinicpal = GetPrincipalFromExpiredToken(model.AccessToken);
+            var principal = GetPrincipalFromExpiredToken(model.AccessToken);
 
-            if (prinicpal?.Identity?.Name is null)
+            if (principal?.Identity?.Name is null)
                 return Unauthorized();
 
-            var user = await _userManager.FindByNameAsync(prinicpal.Identity.Name);
+            var user = await _userManager.FindByNameAsync(principal.Identity.Name);
 
             if (user is null || user.RefreshToken != model.RefreshToken || user.RefreshTokenExpiry < DateTime.UtcNow)
                 return Unauthorized();

--- a/api/ForgetTheBookie.Api/Services/DataFetchingService.cs
+++ b/api/ForgetTheBookie.Api/Services/DataFetchingService.cs
@@ -180,11 +180,15 @@ namespace ForgetTheBookie.Api.Services
                 //var currentExternalLeagues = externalLeagues.Where(x => x.Seasons.Last()).ToList();
                 foreach (var externalLeague in externalLeagues)
                 {
-                    var externalLeagueLatestSeason = externalLeague.Seasons.OrderBy(x => x.Year).FirstOrDefault();
+                    var externalLeagueLatestSeason = externalLeague.Seasons
+                        .OrderByDescending(x => x.Year)
+                        .FirstOrDefault();
                     if (existingLeaguesDict.TryGetValue(externalLeague.League.Id, out var existingLeague))
                     {
                         // Update existing league
-                        var existingLeagueLatestSeason = existingLeague.Seasons.OrderBy(x => x.SeasonYear).FirstOrDefault();
+                        var existingLeagueLatestSeason = existingLeague.Seasons
+                            .OrderByDescending(x => x.SeasonYear)
+                            .FirstOrDefault();
                         //var bothIsCurrent = externalLeagueLatestSeason.Current == existingLeagueLatestSeason.IsCurrent;
 
                         if (existingLeagueLatestSeason.SeasonYear != externalLeagueLatestSeason.Year)
@@ -333,7 +337,9 @@ namespace ForgetTheBookie.Api.Services
             {
                 foreach (var league in existingLeagues)
                 {
-                    var leagueLatestSeason = league.Seasons.OrderBy(x => x.SeasonYear).FirstOrDefault(x => x.IsCurrent);
+                    var leagueLatestSeason = league.Seasons
+                        .FirstOrDefault(x => x.IsCurrent) ??
+                        league.Seasons.OrderByDescending(x => x.SeasonYear).FirstOrDefault();
                     if (leagueLatestSeason != null)
                     {
                         var externalTeams = await GetTeamsForLeagueAsync(league.ExternalId, leagueLatestSeason.SeasonYear);


### PR DESCRIPTION
## Summary
- fix ordering when retrieving the latest season
- ensure fallback for league current season
- fix variable name typo in refresh token logic

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c98f7eeec8322b5f571787af7b8a7