### PR TITLE
Fix League endpoint comment

### DIFF
--- a/api/ForgetTheBookie.Api/Controllers/LeagueController.cs
+++ b/api/ForgetTheBookie.Api/Controllers/LeagueController.cs
@@ -26,7 +26,7 @@ namespace ForgetTheBookie.Api.Controllers
             _mapper = mapper;
         }
 
-        // GET: api/User/GetAllUsers
+        // GET: api/League
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]


### PR DESCRIPTION
## Summary
- correct LeagueController comment to reflect actual GET endpoint

## Testing
- `dotnet build api/ForgetTheBookie.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca059c308832299bf99021fc40c47